### PR TITLE
ダイソーキーボード仕様

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # BLEto98KbMouse
  エレコムのBLEマウスと3COINのBLEキーボードをESP32を用いて、 98用キーボード・バスマウスに変換<br><br>
 [エレコム マウス ワイヤレスマウス SHELLPHA Bluetooth 静音 抗菌 5ボタン ブラック M-SH20BBSKBK](https://amzn.to/4aNvktV)<br>
-[3COINS(スリーコインズ)Bluetoothキーボード](https://www.palcloset.jp/display/item/2008-KP-003-000/?cl=11&b=3coins&ss=)
+ダイソー1000円のフルサイズキーボード　白い奴じゃなくて黒いやつ
 
 ## 必要な機材
  ・ESP32 Dev Board(ESP-WROOM-32)<br>
  ・エレコム マウス ワイヤレスマウス SHELLPHA<br>
- ・3COINS(スリーコインズ)Bluetoothキーボード<br>
+ ・ダイソーBluetoothキーボード<br>
  ※必ず上のメーカーの機材というわけではなくコード修正でなんとかなると思います
 
 ## 開発環境

--- a/src/Pc98BLEKbdRptParser.hpp
+++ b/src/Pc98BLEKbdRptParser.hpp
@@ -6,7 +6,7 @@
 //デバック用
 //#define KEY_B_DEBUG
 //3COINのBLEキーボード用設定有効
-#define BLE_3COIN_KB
+//#define BLE_3COIN_KB
 
 //98側(miniDin8)ピン定義
 #define RST 4 //リセット要求

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ NimBLEAddress Mouse_Ad,Kb_Ad;
 //ペアリング時に通知されるマウス名(一部でもOK) 要事前調査
 const char* MOUSE_NAME_WORD = "shellpha";
 //ペアリング時に通知されるキーボード名(一部でもOK) 要事前調査
-const char* KB_NAME_WORD = "BT WORD";
+const char* KB_NAME_WORD = "BT FullKey";
 
 //LittleFSが使えるかどうかの保持
 static bool isEnable_fs;


### PR DESCRIPTION
#ダイソーBluetoothキーボードへの変更
キーボード名を「BT FullKey」へ変更
3COINキーボートの対応のコメントアウト